### PR TITLE
refactor "require-jsdoc-on-export"

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ None of the rules that are available with this plugin have additional options wh
 
 * `require-jsdoc-on-export`:
 
-    Requires JSDoc docstrings only on exports. This rule allows an additional configuration option specifying on which code constructs JSDocs should be required:
+    Requires JSDoc docstrings only on exports. This rule allows an additional Array configuration option specifying which types of exports to exclude when checking for JSDoc docstrings:
 
     ```json
     {
@@ -240,9 +240,10 @@ None of the rules that are available with this plugin have additional options wh
             "benderthecrime/require-jsdoc-on-export": [
                 2,
                 {
-                  "ClassDeclaration": false,
-                  "FunctionDeclaration": true,
-                  "MethodDefinition": false
+                  "exclude": [
+                      "Literal",
+                      "ObjectExpression"
+                  ]
                 }
             ]
         }

--- a/lib/index.js
+++ b/lib/index.js
@@ -26,6 +26,7 @@ const allRules = Object.assign({}, recommended.rules, {
     ],
     'benderthecrime/no-generator-functions': ERROR,
     'benderthecrime/no-unnecessary-arrow-function': ERROR,
+    'benderthecrime/require-jsdoc-on-export': 0,
     'benderthecrime/sort-keys': [
         ERROR,
         'asc',

--- a/lib/rules/require-jsdoc-on-export.js
+++ b/lib/rules/require-jsdoc-on-export.js
@@ -1,75 +1,37 @@
-const DEFAULT_OPTIONS = {
-    ClassDeclaration: false,
-    FunctionDeclaration: true,
-    MethodDefinition: false,
-};
-
 module.exports = {
     create(context) {
+        const { options } = context;
+        const exclude = [...options[0] && Array.isArray(options[0].exclude) ? options[0].exclude : []];
         const source = context.getSourceCode();
-        let options = DEFAULT_OPTIONS;
 
-        if (context.options[0] && context.options[0].require) {
-            options = Object.assign({}, DEFAULT_OPTIONS, context.options[0].require);
-        }
-
-        function checkClassMethodJsDoc(node) {
-            if (node.parent.type === 'MethodDefinition') {
-                const jsdocComment = source.getJSDocComment(node);
-
-                if (!jsdocComment && isExportNode(node)) {
-                    report(node);
-                }
+        function checkJSDoc(node) {
+            if (!source.getJSDocComment(node)) {
+                context.report(node, 'Missing JSDoc comment.');
             }
         }
 
-        function checkJsDoc(node) {
-            const jsdocComment = source.getJSDocComment(node);
-
-            if (!jsdocComment && isExportNode(node)) {
-                report(node);
-            }
+        function isExcludedNodeType(node) {
+            return exclude.indexOf(node.type) > -1;
         }
 
-        function isExportNode(node) {
-            const parentType = node.parent && node.parent.type;
-
-            if (parentType) {
-                return [
-                    'ExportDefaultDeclaration',
-                    'ExportNamedDeclaration',
-                ].includes(parentType);
-            }
-
-            return false;
-        }
-
-        function report(node) {
-            context.report(node, 'Missing JSDoc comment.');
+        function isModuleExportsExpression(node) {
+            return node.object && node.object.name === 'module' && node.property && node.property.name === 'exports';
         }
 
         return {
-            ArrowFunctionExpression(node) {
-                if (
-                    options.ArrowFunctionExpression &&
-                    node.parent.type === 'VariableDeclarator'
-                ) {
-                    checkJsDoc(node);
+            ExportDefaultDeclaration(node) {
+                if (!isExcludedNodeType(node.declaration)) {
+                    checkJSDoc(node);
                 }
             },
-            ClassDeclaration(node) {
-                if (options.ClassDeclaration) {
-                    checkJsDoc(node);
+            ExportNamedDeclaration(node) {
+                if (!isExcludedNodeType(node.declaration)) {
+                    checkJSDoc(node);
                 }
             },
-            FunctionDeclaration(node) {
-                if (options.FunctionDeclaration) {
-                    checkJsDoc(node);
-                }
-            },
-            FunctionExpression(node) {
-                if (options.MethodDefinition) {
-                    checkClassMethodJsDoc(node);
+            MemberExpression(node) {
+                if (isModuleExportsExpression(node) && !isExcludedNodeType(node.parent.right)) {
+                    checkJSDoc(node.parent);
                 }
             },
         };
@@ -77,13 +39,19 @@ module.exports = {
     meta: {
         docs: {
             category: 'Stylistic Issues',
-            description: 'Require JSDoc comments on exports',
+            description: 'Require JSDoc comments on exports.',
             recommended: false,
         },
         schema: [
             {
                 additionalProperties: false,
-                type: 'number',
+                properties: {
+                    exclude: {
+                        additionalProperties: false,
+                        type: 'Array',
+                    },
+                },
+                type: 'object',
             },
         ],
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -2,6 +2,7 @@
   "name": "eslint-plugin-benderthecrime",
   "version": "2.0.0",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "acorn": {
       "version": "5.0.3",
@@ -14,6 +15,9 @@
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
+      "requires": {
+        "acorn": "3.3.0"
+      },
       "dependencies": {
         "acorn": {
           "version": "3.3.0",
@@ -27,7 +31,11 @@
       "version": "4.11.8",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/ajv/-/ajv-4.11.8.tgz",
       "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "co": "4.6.0",
+        "json-stable-stringify": "1.0.1"
+      }
     },
     "ajv-keywords": {
       "version": "1.5.1",
@@ -38,8 +46,7 @@
     "ansi-escapes": {
       "version": "2.0.0",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/ansi-escapes/-/ansi-escapes-2.0.0.tgz",
-      "integrity": "sha1-W65SvkJIeN2Xg+iRDj/Cki6DyBs=",
-      "dev": true
+      "integrity": "sha1-W65SvkJIeN2Xg+iRDj/Cki6DyBs="
     },
     "ansi-regex": {
       "version": "2.1.1",
@@ -57,13 +64,19 @@
       "version": "1.0.9",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/argparse/-/argparse-1.0.9.tgz",
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "sprintf-js": "1.0.3"
+      }
     },
     "array-union": {
       "version": "1.0.2",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "array-uniq": "1.0.3"
+      }
     },
     "array-uniq": {
       "version": "1.0.3",
@@ -81,37 +94,70 @@
       "version": "6.22.0",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
       "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.1"
+      }
     },
     "babel-eslint": {
       "version": "7.2.3",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/babel-eslint/-/babel-eslint-7.2.3.tgz",
       "integrity": "sha1-sv4tgBJkcPXBlELcdXJTqJdxCCc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "6.22.0",
+        "babel-traverse": "6.25.0",
+        "babel-types": "6.25.0"
+      }
     },
     "babel-messages": {
       "version": "6.23.0",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/babel-messages/-/babel-messages-6.23.0.tgz",
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0"
+      }
     },
     "babel-runtime": {
       "version": "6.23.0",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/babel-runtime/-/babel-runtime-6.23.0.tgz",
       "integrity": "sha1-CpSJ8UTecO+zzkMArM2zKeL8VDs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "core-js": "2.4.1",
+        "regenerator-runtime": "0.10.5"
+      }
     },
     "babel-traverse": {
       "version": "6.25.0",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/babel-traverse/-/babel-traverse-6.25.0.tgz",
       "integrity": "sha1-IldJfi/NGbie3BPEyROB+VEklvE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "6.22.0",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.25.0",
+        "debug": "2.6.8",
+        "globals": "9.18.0",
+        "invariant": "2.2.2",
+        "lodash": "4.17.4"
+      }
     },
     "babel-types": {
       "version": "6.25.0",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/babel-types/-/babel-types-6.25.0.tgz",
       "integrity": "sha1-cK+ySNVmDl0Y+BHZHIMDtUE0oY4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "esutils": "2.0.2",
+        "lodash": "4.17.4",
+        "to-fast-properties": "1.0.3"
+      }
     },
     "babylon": {
       "version": "6.17.3",
@@ -129,7 +175,11 @@
       "version": "1.1.8",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
     },
     "browser-stdout": {
       "version": "1.3.0",
@@ -141,7 +191,10 @@
       "version": "0.1.0",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/caller-path/-/caller-path-0.1.0.tgz",
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "callsites": "0.2.0"
+      }
     },
     "callsites": {
       "version": "0.2.0",
@@ -153,7 +206,14 @@
       "version": "1.1.3",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
+      }
     },
     "ci-info": {
       "version": "1.0.0",
@@ -171,13 +231,14 @@
       "version": "2.1.0",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/cli-cursor/-/cli-cursor-2.1.0.tgz",
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-      "dev": true
+      "requires": {
+        "restore-cursor": "2.0.0"
+      }
     },
     "cli-width": {
       "version": "2.1.0",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/cli-width/-/cli-width-2.1.0.tgz",
-      "integrity": "sha1-sjTKIJsp72b8UY2bmNWEewDt8Ao=",
-      "dev": true
+      "integrity": "sha1-sjTKIJsp72b8UY2bmNWEewDt8Ao="
     },
     "co": {
       "version": "4.6.0",
@@ -189,7 +250,10 @@
       "version": "2.9.0",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/commander/-/commander-2.9.0.tgz",
       "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-readlink": "1.0.1"
+      }
     },
     "concat-map": {
       "version": "0.0.1",
@@ -201,7 +265,12 @@
       "version": "1.6.0",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/concat-stream/-/concat-stream-1.6.0.tgz",
       "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.2.11",
+        "typedarray": "0.0.6"
+      }
     },
     "core-js": {
       "version": "2.4.1",
@@ -219,7 +288,10 @@
       "version": "2.6.8",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/debug/-/debug-2.6.8.tgz",
       "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
     },
     "deep-is": {
       "version": "0.1.3",
@@ -231,7 +303,16 @@
       "version": "2.2.2",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/del/-/del-2.2.2.tgz",
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "globby": "5.0.0",
+        "is-path-cwd": "1.0.0",
+        "is-path-in-cwd": "1.0.0",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "rimraf": "2.6.1"
+      }
     },
     "diff": {
       "version": "3.2.0",
@@ -243,31 +324,75 @@
       "version": "2.0.0",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/doctrine/-/doctrine-2.0.0.tgz",
       "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "esutils": "2.0.2",
+        "isarray": "1.0.0"
+      }
     },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "eslint": {
       "version": "4.0.0",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/eslint/-/eslint-4.0.0.tgz",
       "integrity": "sha1-cnfAFDf99B3M0WjVqg5Jt1yh8mA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "6.22.0",
+        "chalk": "1.1.3",
+        "concat-stream": "1.6.0",
+        "debug": "2.6.8",
+        "doctrine": "2.0.0",
+        "eslint-scope": "3.7.1",
+        "espree": "3.4.3",
+        "esquery": "1.0.0",
+        "estraverse": "4.2.0",
+        "esutils": "2.0.2",
+        "file-entry-cache": "2.0.0",
+        "glob": "7.1.2",
+        "globals": "9.18.0",
+        "ignore": "3.3.3",
+        "imurmurhash": "0.1.4",
+        "is-my-json-valid": "2.16.0",
+        "is-resolvable": "1.0.0",
+        "js-yaml": "3.8.4",
+        "json-stable-stringify": "1.0.1",
+        "levn": "0.3.0",
+        "lodash": "4.17.4",
+        "mkdirp": "0.5.1",
+        "natural-compare": "1.4.0",
+        "optionator": "0.8.2",
+        "path-is-inside": "1.0.2",
+        "pluralize": "4.0.0",
+        "progress": "2.0.0",
+        "require-uncached": "1.0.3",
+        "strip-json-comments": "2.0.1",
+        "table": "4.0.1",
+        "text-table": "0.2.0"
+      }
     },
     "eslint-scope": {
       "version": "3.7.1",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/eslint-scope/-/eslint-scope-3.7.1.tgz",
       "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "esrecurse": "4.1.0",
+        "estraverse": "4.2.0"
+      }
     },
     "espree": {
       "version": "3.4.3",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/espree/-/espree-3.4.3.tgz",
       "integrity": "sha1-KRC1zNSc6JPC//+qtP2LOjG4I3Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "acorn": "5.0.3",
+        "acorn-jsx": "3.0.1"
+      }
     },
     "esprima": {
       "version": "3.1.3",
@@ -279,13 +404,20 @@
       "version": "1.0.0",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/esquery/-/esquery-1.0.0.tgz",
       "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "estraverse": "4.2.0"
+      }
     },
     "esrecurse": {
       "version": "4.1.0",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/esrecurse/-/esrecurse-4.1.0.tgz",
       "integrity": "sha1-RxO2U2rffyrE8yfVWed1a/9kgiA=",
       "dev": true,
+      "requires": {
+        "estraverse": "4.1.1",
+        "object-assign": "4.1.1"
+      },
       "dependencies": {
         "estraverse": {
           "version": "4.1.1",
@@ -311,7 +443,11 @@
       "version": "2.0.4",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/external-editor/-/external-editor-2.0.4.tgz",
       "integrity": "sha1-HtkZnanL/i7y96MbL96LDRI2iXI=",
-      "dev": true
+      "requires": {
+        "iconv-lite": "0.4.18",
+        "jschardet": "1.4.2",
+        "tmp": "0.0.31"
+      }
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -323,13 +459,19 @@
       "version": "2.0.0",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/figures/-/figures-2.0.0.tgz",
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
-      "dev": true
+      "requires": {
+        "escape-string-regexp": "1.0.5"
+      }
     },
     "file-entry-cache": {
       "version": "2.0.0",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "flat-cache": "1.2.2",
+        "object-assign": "4.1.1"
+      }
     },
     "find-parent-dir": {
       "version": "0.3.0",
@@ -341,7 +483,13 @@
       "version": "1.2.2",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/flat-cache/-/flat-cache-1.2.2.tgz",
       "integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "circular-json": "0.3.1",
+        "del": "2.2.2",
+        "graceful-fs": "4.1.11",
+        "write": "0.2.1"
+      }
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -359,13 +507,24 @@
       "version": "1.2.0",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/generate-object-property/-/generate-object-property-1.2.0.tgz",
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-property": "1.0.2"
+      }
     },
     "glob": {
       "version": "7.1.2",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/glob/-/glob-7.1.2.tgz",
       "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
     },
     "globals": {
       "version": "9.18.0",
@@ -377,7 +536,15 @@
       "version": "5.0.0",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/globby/-/globby-5.0.0.tgz",
       "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "array-union": "1.0.2",
+        "arrify": "1.0.1",
+        "glob": "7.1.2",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
+      }
     },
     "graceful-fs": {
       "version": "4.1.11",
@@ -401,7 +568,10 @@
       "version": "2.0.0",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
     },
     "has-flag": {
       "version": "1.0.0",
@@ -413,13 +583,18 @@
       "version": "0.13.4",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/husky/-/husky-0.13.4.tgz",
       "integrity": "sha1-SHhcUCjeNFKlHEjBLE+UshJKFAc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "find-parent-dir": "0.3.0",
+        "is-ci": "1.0.10",
+        "normalize-path": "1.0.0"
+      }
     },
     "iconv-lite": {
       "version": "0.4.18",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/iconv-lite/-/iconv-lite-0.4.18.tgz",
-      "integrity": "sha1-I9hlaxaq5nQqwpcy6o8DNqR4nPI=",
-      "dev": true
+      "integrity": "sha1-I9hlaxaq5nQqwpcy6o8DNqR4nPI="
     },
     "ignore": {
       "version": "3.3.3",
@@ -437,7 +612,11 @@
       "version": "1.0.6",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
     },
     "inherits": {
       "version": "2.0.3",
@@ -455,13 +634,19 @@
       "version": "2.2.2",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/invariant/-/invariant-2.2.2.tgz",
       "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "loose-envify": "1.3.1"
+      }
     },
     "is-ci": {
       "version": "1.0.10",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/is-ci/-/is-ci-1.0.10.tgz",
       "integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ci-info": "1.0.0"
+      }
     },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
@@ -473,7 +658,13 @@
       "version": "2.16.0",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
       "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "generate-function": "2.0.0",
+        "generate-object-property": "1.2.0",
+        "jsonpointer": "4.0.1",
+        "xtend": "4.0.1"
+      }
     },
     "is-path-cwd": {
       "version": "1.0.0",
@@ -485,19 +676,24 @@
       "version": "1.0.0",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
       "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-path-inside": "1.0.0"
+      }
     },
     "is-path-inside": {
       "version": "1.0.0",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/is-path-inside/-/is-path-inside-1.0.0.tgz",
       "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "path-is-inside": "1.0.2"
+      }
     },
     "is-promise": {
       "version": "2.1.0",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/is-promise/-/is-promise-2.1.0.tgz",
-      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
-      "dev": true
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
     },
     "is-property": {
       "version": "1.0.2",
@@ -509,7 +705,10 @@
       "version": "1.0.0",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/is-resolvable/-/is-resolvable-1.0.0.tgz",
       "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "tryit": "1.0.3"
+      }
     },
     "isarray": {
       "version": "1.0.0",
@@ -527,19 +726,25 @@
       "version": "3.8.4",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/js-yaml/-/js-yaml-3.8.4.tgz",
       "integrity": "sha1-UgtFZPhlc7qWZir4Woyvp7S1pvY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "argparse": "1.0.9",
+        "esprima": "3.1.3"
+      }
     },
     "jschardet": {
       "version": "1.4.2",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/jschardet/-/jschardet-1.4.2.tgz",
-      "integrity": "sha1-KqEH8UKvQSHRRWWdRPUIMJYeaZo=",
-      "dev": true
+      "integrity": "sha1-KqEH8UKvQSHRRWWdRPUIMJYeaZo="
     },
     "json-stable-stringify": {
       "version": "1.0.1",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "jsonify": "0.0.0"
+      }
     },
     "json3": {
       "version": "3.3.2",
@@ -563,7 +768,11 @@
       "version": "0.3.0",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
+      }
     },
     "lodash": {
       "version": "4.17.4",
@@ -575,7 +784,11 @@
       "version": "3.2.0",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
       "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._basecopy": "3.0.1",
+        "lodash.keys": "3.1.2"
+      }
     },
     "lodash._basecopy": {
       "version": "3.0.1",
@@ -605,7 +818,12 @@
       "version": "3.1.1",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/lodash.create/-/lodash.create-3.1.1.tgz",
       "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._baseassign": "3.2.0",
+        "lodash._basecreate": "3.0.3",
+        "lodash._isiterateecall": "3.0.9"
+      }
     },
     "lodash.isarguments": {
       "version": "3.1.0",
@@ -623,25 +841,35 @@
       "version": "3.1.2",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/lodash.keys/-/lodash.keys-3.1.2.tgz",
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._getnative": "3.9.1",
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4"
+      }
     },
     "loose-envify": {
       "version": "1.3.1",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/loose-envify/-/loose-envify-1.3.1.tgz",
       "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "js-tokens": "3.0.1"
+      }
     },
     "mimic-fn": {
       "version": "1.1.0",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/mimic-fn/-/mimic-fn-1.1.0.tgz",
-      "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
-      "dev": true
+      "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg="
     },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "brace-expansion": "1.1.8"
+      }
     },
     "minimist": {
       "version": "0.0.8",
@@ -653,25 +881,52 @@
       "version": "0.5.1",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
     },
     "mocha": {
       "version": "3.4.2",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/mocha/-/mocha-3.4.2.tgz",
       "integrity": "sha1-0O9NMyEm2/GNDWQMmzgt1IvpdZQ=",
       "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.0",
+        "commander": "2.9.0",
+        "debug": "2.6.0",
+        "diff": "3.2.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.1",
+        "growl": "1.9.2",
+        "json3": "3.3.2",
+        "lodash.create": "3.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "3.1.2"
+      },
       "dependencies": {
         "debug": {
           "version": "2.6.0",
           "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/debug/-/debug-2.6.0.tgz",
           "integrity": "sha1-vFlryr52F/Edn6FTYe3tVgi4SZs=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "0.7.2"
+          }
         },
         "glob": {
           "version": "7.1.1",
           "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/glob/-/glob-7.1.1.tgz",
           "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
         },
         "ms": {
           "version": "0.7.2",
@@ -683,7 +938,10 @@
           "version": "3.1.2",
           "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/supports-color/-/supports-color-3.1.2.tgz",
           "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "has-flag": "1.0.0"
+          }
         }
       }
     },
@@ -696,8 +954,7 @@
     "mute-stream": {
       "version": "0.0.7",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/mute-stream/-/mute-stream-0.0.7.tgz",
-      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
-      "dev": true
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -721,25 +978,37 @@
       "version": "1.4.0",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
     },
     "onetime": {
       "version": "2.0.1",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/onetime/-/onetime-2.0.1.tgz",
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-      "dev": true
+      "requires": {
+        "mimic-fn": "1.1.0"
+      }
     },
     "optionator": {
       "version": "0.8.2",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
+      }
     },
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-      "dev": true
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -769,7 +1038,10 @@
       "version": "2.0.1",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "pinkie": "2.0.4"
+      }
     },
     "pluralize": {
       "version": "4.0.0",
@@ -799,7 +1071,16 @@
       "version": "2.2.11",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/readable-stream/-/readable-stream-2.2.11.tgz",
       "integrity": "sha1-B5azH412iAB/8Lk6gIjTSqF8D3I=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "1.0.7",
+        "safe-buffer": "5.0.1",
+        "string_decoder": "1.0.2",
+        "util-deprecate": "1.0.2"
+      }
     },
     "regenerator-runtime": {
       "version": "0.10.5",
@@ -811,7 +1092,11 @@
       "version": "1.0.3",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/require-uncached/-/require-uncached-1.0.3.tgz",
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "caller-path": "0.1.0",
+        "resolve-from": "1.0.1"
+      }
     },
     "requireindex": {
       "version": "1.1.0",
@@ -828,31 +1113,40 @@
       "version": "2.0.0",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/restore-cursor/-/restore-cursor-2.0.0.tgz",
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-      "dev": true
+      "requires": {
+        "onetime": "2.0.1",
+        "signal-exit": "3.0.2"
+      }
     },
     "rimraf": {
       "version": "2.6.1",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/rimraf/-/rimraf-2.6.1.tgz",
       "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "glob": "7.1.2"
+      }
     },
     "run-async": {
       "version": "2.3.0",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/run-async/-/run-async-2.3.0.tgz",
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
-      "dev": true
+      "requires": {
+        "is-promise": "2.1.0"
+      }
     },
     "rx-lite": {
       "version": "4.0.8",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/rx-lite/-/rx-lite-4.0.8.tgz",
-      "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
-      "dev": true
+      "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ="
     },
     "rx-lite-aggregates": {
       "version": "4.0.8",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
       "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
-      "dev": true
+      "requires": {
+        "rx-lite": "4.0.8"
+      }
     },
     "safe-buffer": {
       "version": "5.0.1",
@@ -863,8 +1157,7 @@
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-      "dev": true
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "slice-ansi": {
       "version": "0.0.4",
@@ -882,19 +1175,29 @@
       "version": "1.0.2",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/string_decoder/-/string_decoder-1.0.2.tgz",
       "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.0.1"
+      }
     },
     "string-width": {
       "version": "2.0.0",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/string-width/-/string-width-2.0.0.tgz",
       "integrity": "sha1-Y1xUNsxypuDDh87KJ41OLuxSaH4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-fullwidth-code-point": "2.0.0",
+        "strip-ansi": "3.0.1"
+      }
     },
     "strip-ansi": {
       "version": "3.0.1",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
     },
     "strip-json-comments": {
       "version": "2.0.1",
@@ -912,7 +1215,15 @@
       "version": "4.0.1",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/table/-/table-4.0.1.tgz",
       "integrity": "sha1-qBFsEz+sLGH0pCCrbN9cTWHw5DU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ajv": "4.11.8",
+        "ajv-keywords": "1.5.1",
+        "chalk": "1.1.3",
+        "lodash": "4.17.4",
+        "slice-ansi": "0.0.4",
+        "string-width": "2.0.0"
+      }
     },
     "text-table": {
       "version": "0.2.0",
@@ -923,14 +1234,15 @@
     "through": {
       "version": "2.3.8",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-      "dev": true
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "tmp": {
       "version": "0.0.31",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/tmp/-/tmp-0.0.31.tgz",
       "integrity": "sha1-jzirlDjhcxXl29izZX6L+yd65Kc=",
-      "dev": true
+      "requires": {
+        "os-tmpdir": "1.0.2"
+      }
     },
     "to-fast-properties": {
       "version": "1.0.3",
@@ -948,7 +1260,10 @@
       "version": "0.3.2",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2"
+      }
     },
     "typedarray": {
       "version": "0.0.6",
@@ -978,7 +1293,10 @@
       "version": "0.2.1",
       "resolved": "http://artifactory.es.ad.adp.com:8081/artifactory/api/npm/ohcm-npms/write/-/write-0.2.1.tgz",
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "mkdirp": "0.5.1"
+      }
     },
     "xtend": {
       "version": "4.0.1",


### PR DESCRIPTION
Now, the rule only works with ExportStatement, ExportDefaultStatement, and MemberExpressions whose parent ExpressionStatements match `module.exports = ...`. I've also standardized the way that the first positional Object argument takes in exclusions with an Array key named "exclude" (Perhaps this key should actually be called "excludeTypes"?).

This change completely changes the contract with the existing require-jsdoc-on-export, so this is a breaking change. Likely this will be a major version update. Alternatively, I could change the name of the rule.